### PR TITLE
Fix blank sqlPassword issue

### DIFF
--- a/artifacts/environment-setup/automation/01-environment-setup.ps1
+++ b/artifacts/environment-setup/automation/01-environment-setup.ps1
@@ -160,7 +160,15 @@ $amlid = (Get-AzADServicePrincipal -DisplayName $amlworkspacename).id
 Set-AzKeyVaultAccessPolicy -ResourceGroupName $resourceGroupName -VaultName $keyVaultName -ObjectId $amlid -PermissionsToSecrets set,delete,get,list
 
 #remove need to ask for the password in script.
-$global:sqlPassword = $(Get-AzKeyVaultSecret -VaultName $keyVaultName -Name "SqlPassword").SecretValueText
+$sqlPasswordSecret = Get-AzKeyVaultSecret -VaultName $keyVaultName -Name "SqlPassword"
+$sqlPassword = '';
+$ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlPasswordSecret.SecretValue)
+try {
+    $sqlPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr)
+} finally {
+    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ssPtr)
+}
+$global:sqlPassword = $sqlPassword
 
 Write-Information "Create SQL-USER-ASA Key Vault Secret"
 $secretValue = ConvertTo-SecureString $sqlPassword -AsPlainText -Force


### PR DESCRIPTION
The `Get-AzKeyVaultSecret` return value's `SecretValueText` was returning an empty string, causing SQL auth issues.